### PR TITLE
[FEAT]: 게시글 CRUD 기능 구현

### DIFF
--- a/back/src/main/java/com/back/domain/post/controller/PostController.java
+++ b/back/src/main/java/com/back/domain/post/controller/PostController.java
@@ -7,10 +7,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 게시글 관련 API 요청을 처리하는 컨트롤러.
@@ -29,5 +28,18 @@ public class PostController {
         Long userId = 1L; // fixme 임시 사용자 ID
         PostResponse response = postService.createPost(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 게시글 목록 조회
+    @GetMapping
+    public ResponseEntity<List<PostResponse>> getPosts() {
+        List<PostResponse> responses = postService.getPosts();
+        return ResponseEntity.ok(responses);
+    }
+
+    // 게시글 단건 조회
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
+        return ResponseEntity.ok(postService.getPost(postId));
     }
 }

--- a/back/src/main/java/com/back/domain/post/controller/PostController.java
+++ b/back/src/main/java/com/back/domain/post/controller/PostController.java
@@ -42,4 +42,12 @@ public class PostController {
     public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
         return ResponseEntity.ok(postService.getPost(postId));
     }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostResponse> updatePost(
+            @PathVariable Long postId,
+            @RequestBody @Valid PostRequest request) {
+        Long userId = 1L; // fixme 임시 사용자 ID
+        return ResponseEntity.ok(postService.updatePost(userId, postId, request));
+    }
 }

--- a/back/src/main/java/com/back/domain/post/controller/PostController.java
+++ b/back/src/main/java/com/back/domain/post/controller/PostController.java
@@ -50,4 +50,11 @@ public class PostController {
         Long userId = 1L; // fixme 임시 사용자 ID
         return ResponseEntity.ok(postService.updatePost(userId, postId, request));
     }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
+        Long userId = 1L; // fixme 임시 사용자 ID
+        postService.deletePost(userId, postId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/back/src/main/java/com/back/domain/post/controller/PostController.java
+++ b/back/src/main/java/com/back/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.back.domain.post.controller;
 import com.back.domain.post.dto.PostRequest;
 import com.back.domain.post.dto.PostResponse;
 import com.back.domain.post.service.PostService;
+import com.back.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,38 +24,38 @@ public class PostController {
 
     // 게시글 생성
     @PostMapping
-    public ResponseEntity<PostResponse> createPost(
+    public ApiResponse<PostResponse> createPost(
             @RequestBody @Valid PostRequest request) {
         Long userId = 1L; // fixme 임시 사용자 ID
         PostResponse response = postService.createPost(userId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ApiResponse.success(response, "성공적으로 생성되었습니다.", HttpStatus.CREATED);
     }
 
     // 게시글 목록 조회
     @GetMapping
-    public ResponseEntity<List<PostResponse>> getPosts() {
+    public ApiResponse<List<PostResponse>> getPosts() {
         List<PostResponse> responses = postService.getPosts();
-        return ResponseEntity.ok(responses);
+        return ApiResponse.success(responses, "성공적으로 조회되었습니다.", HttpStatus.OK);
     }
 
     // 게시글 단건 조회
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
-        return ResponseEntity.ok(postService.getPost(postId));
+    public ApiResponse<PostResponse> getPost(@PathVariable Long postId) {
+        return ApiResponse.success(postService.getPost(postId), "성공적으로 조회되었습니다.", HttpStatus.OK);
     }
 
     @PutMapping("/{postId}")
-    public ResponseEntity<PostResponse> updatePost(
+    public ApiResponse<PostResponse> updatePost(
             @PathVariable Long postId,
             @RequestBody @Valid PostRequest request) {
         Long userId = 1L; // fixme 임시 사용자 ID
-        return ResponseEntity.ok(postService.updatePost(userId, postId, request));
+        return ApiResponse.success(postService.updatePost(userId, postId, request), "성공적으로 수정되었습니다.", HttpStatus.OK);
     }
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
+    public ApiResponse<Void> deletePost(@PathVariable Long postId) {
         Long userId = 1L; // fixme 임시 사용자 ID
         postService.deletePost(userId, postId);
-        return ResponseEntity.ok().build();
+        return ApiResponse.success(null, "성공적으로 삭제되었습니다.", HttpStatus.OK);
     }
 }

--- a/back/src/main/java/com/back/domain/post/controller/PostController.java
+++ b/back/src/main/java/com/back/domain/post/controller/PostController.java
@@ -4,8 +4,11 @@ import com.back.domain.post.dto.PostRequest;
 import com.back.domain.post.dto.PostResponse;
 import com.back.domain.post.service.PostService;
 import com.back.global.common.ApiResponse;
+import com.back.global.common.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,14 +31,14 @@ public class PostController {
             @RequestBody @Valid PostRequest request) {
         Long userId = 1L; // fixme 임시 사용자 ID
         PostResponse response = postService.createPost(userId, request);
-        return ApiResponse.success(response, "성공적으로 생성되었습니다.", HttpStatus.CREATED);
+        return ApiResponse.success(response, "성공적으로 생성되었습니다.", HttpStatus.OK);
     }
 
     // 게시글 목록 조회
     @GetMapping
-    public ApiResponse<List<PostResponse>> getPosts() {
-        List<PostResponse> responses = postService.getPosts();
-        return ApiResponse.success(responses, "성공적으로 조회되었습니다.", HttpStatus.OK);
+    public ApiResponse<PageResponse<PostResponse>> getPosts(Pageable pageable) {
+        Page<PostResponse> responses = postService.getPosts(pageable);
+        return ApiResponse.success(PageResponse.of(responses), "성공적으로 조회되었습니다.", HttpStatus.OK);
     }
 
     // 게시글 단건 조회

--- a/back/src/main/java/com/back/domain/post/controller/PostController.java
+++ b/back/src/main/java/com/back/domain/post/controller/PostController.java
@@ -1,7 +1,14 @@
 package com.back.domain.post.controller;
 
+import com.back.domain.post.dto.PostRequest;
+import com.back.domain.post.dto.PostResponse;
 import com.back.domain.post.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,4 +22,12 @@ public class PostController {
 
     private final PostService postService;
 
+    // 게시글 생성
+    @PostMapping
+    public ResponseEntity<PostResponse> createPost(
+            @RequestBody @Valid PostRequest request) {
+        Long userId = 1L; // fixme 임시 사용자 ID
+        PostResponse response = postService.createPost(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }

--- a/back/src/main/java/com/back/domain/post/dto/PostRequest.java
+++ b/back/src/main/java/com/back/domain/post/dto/PostRequest.java
@@ -1,9 +1,18 @@
 package com.back.domain.post.dto;
 
 import com.back.domain.post.enums.PostCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record PostRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다")
         String title,
+
+        @NotBlank(message = "내용은 필수입니다")
         String content,
+
+        @NotNull(message = "카테고리는 필수입니다")
         PostCategory category
 ) { }

--- a/back/src/main/java/com/back/domain/post/dto/PostRequest.java
+++ b/back/src/main/java/com/back/domain/post/dto/PostRequest.java
@@ -1,0 +1,9 @@
+package com.back.domain.post.dto;
+
+import com.back.domain.post.enums.PostCategory;
+
+public record PostRequest(
+        String title,
+        String content,
+        PostCategory category
+) { }

--- a/back/src/main/java/com/back/domain/post/dto/PostResponse.java
+++ b/back/src/main/java/com/back/domain/post/dto/PostResponse.java
@@ -1,0 +1,25 @@
+package com.back.domain.post.dto;
+
+import com.back.domain.post.enums.PostCategory;
+
+import java.time.LocalDateTime;
+
+/**
+ * @param id
+ * @param title
+ * @param content
+ * @param category
+ * @param hide
+ * @param likeCount
+ * @param createdAt
+ * fixme @param createdBy 추가 예정
+ */
+public record PostResponse(
+        Long id,
+        String title,
+        String content,
+        PostCategory category,
+        boolean hide,
+        int likeCount,
+        LocalDateTime createdAt
+) { }

--- a/back/src/main/java/com/back/domain/post/dto/PostResponse.java
+++ b/back/src/main/java/com/back/domain/post/dto/PostResponse.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
  * @param category
  * @param hide
  * @param likeCount
- * @param createdAt
+ * @param createdDate
  * fixme @param createdBy 추가 예정
  */
 public record PostResponse(
@@ -21,5 +21,5 @@ public record PostResponse(
         PostCategory category,
         boolean hide,
         int likeCount,
-        LocalDateTime createdAt
+        LocalDateTime createdDate
 ) { }

--- a/back/src/main/java/com/back/domain/post/entity/Post.java
+++ b/back/src/main/java/com/back/domain/post/entity/Post.java
@@ -1,13 +1,10 @@
 package com.back.domain.post.entity;
 
+import com.back.domain.post.enums.PostCategory;
 import com.back.domain.user.entity.User;
 import com.back.global.baseentity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -19,9 +16,8 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class Post extends BaseEntity {
 
@@ -32,13 +28,16 @@ public class Post extends BaseEntity {
     @Column(length = 200)
     private String title;
 
-    @Column(length = 200)
-    private String category;
+    @Column(length = 20)
+    @Enumerated(EnumType.STRING)
+    private PostCategory category;
 
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    @Column(columnDefinition = "jsonb")
+    /**
+     * JSON 데이터를 단순 문자열로 저장 (예: {"option1": 10, "option2": 5})
+     */
     private String voteContent;
 
     @Column(nullable = false)

--- a/back/src/main/java/com/back/domain/post/entity/Post.java
+++ b/back/src/main/java/com/back/domain/post/entity/Post.java
@@ -52,4 +52,10 @@ public class Post extends BaseEntity {
     public void assignUser(User user) {
         this.user = user;
     }
+
+    public void updatePost(String title, String content, PostCategory category) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+    }
 }

--- a/back/src/main/java/com/back/domain/post/entity/Post.java
+++ b/back/src/main/java/com/back/domain/post/entity/Post.java
@@ -48,4 +48,8 @@ public class Post extends BaseEntity {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void assignUser(User user) {
+        this.user = user;
+    }
 }

--- a/back/src/main/java/com/back/domain/post/entity/Post.java
+++ b/back/src/main/java/com/back/domain/post/entity/Post.java
@@ -3,9 +3,12 @@ package com.back.domain.post.entity;
 import com.back.domain.post.enums.PostCategory;
 import com.back.domain.user.entity.User;
 import com.back.global.baseentity.BaseEntity;
+import com.back.global.exception.ApiException;
+import com.back.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.service.spi.ServiceException;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
@@ -57,5 +60,10 @@ public class Post extends BaseEntity {
         this.title = title;
         this.content = content;
         this.category = category;
+    }
+
+    public void checkUser(User targetUser) {
+        if (!user.equals(targetUser))
+            throw new ApiException(ErrorCode.UNAUTHORIZED_USER);
     }
 }

--- a/back/src/main/java/com/back/domain/post/enums/PostCategory.java
+++ b/back/src/main/java/com/back/domain/post/enums/PostCategory.java
@@ -1,0 +1,7 @@
+package com.back.domain.post.enums;
+
+public enum PostCategory {
+    CHAT,       // 잡담
+    SCENARIO,   // 시나리오 첨부
+    POLL        // 투표
+}

--- a/back/src/main/java/com/back/domain/post/mapper/PostMapper.java
+++ b/back/src/main/java/com/back/domain/post/mapper/PostMapper.java
@@ -1,0 +1,41 @@
+package com.back.domain.post.mapper;
+
+import com.back.domain.post.dto.PostRequest;
+import com.back.domain.post.dto.PostResponse;
+import com.back.domain.post.entity.Post;
+
+import java.util.List;
+
+/**
+ * PostMapper
+ * 엔티티와 PostRequest, PostResponse 간의 변환을 담당하는 매퍼 클래스
+ */
+public abstract class PostMapper {
+    public static Post toEntity(PostRequest request) {
+        return Post.builder()
+                .title(request.title())
+                .content(request.content())
+                .category(request.category())
+                .hide(false)
+                .likeCount(0)
+                .build();
+    }
+
+    public static PostResponse toResponse(Post post) {
+        return new PostResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getCategory(),
+                post.isHide(),
+                post.getLikeCount(),
+                post.getCreatedDate()
+        );
+    }
+
+    public static List<PostResponse> toResponseList(List<Post> posts) {
+        return posts.stream()
+                .map(PostMapper::toResponse)
+                .toList();
+    }
+}

--- a/back/src/main/java/com/back/domain/post/service/PostService.java
+++ b/back/src/main/java/com/back/domain/post/service/PostService.java
@@ -10,6 +10,8 @@ import com.back.domain.user.repository.UserRepository;
 import com.back.global.exception.ApiException;
 import com.back.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,13 +48,9 @@ public class PostService {
                 .orElseThrow(() -> new ApiException(ErrorCode.POST_NOT_FOUND));
     }
 
-    public List<PostResponse> getPosts() {
-        List<Post> posts = postRepository.findAll()
-                .stream()
-                .filter(post -> !post.isHide())
-                .toList();
-
-        return PostMapper.toResponseList(posts);
+    public Page<PostResponse> getPosts(Pageable pageable) {
+        return postRepository.findAll(pageable)
+                .map(PostMapper::toResponse);
     }
 
     @Transactional

--- a/back/src/main/java/com/back/domain/post/service/PostService.java
+++ b/back/src/main/java/com/back/domain/post/service/PostService.java
@@ -1,16 +1,37 @@
 package com.back.domain.post.service;
 
+import com.back.domain.post.dto.PostRequest;
+import com.back.domain.post.dto.PostResponse;
+import com.back.domain.post.entity.Post;
+import com.back.domain.post.mapper.PostMapper;
 import com.back.domain.post.repository.PostRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 게시글 관련 비즈니스 로직을 처리하는 서비스.
  */
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PostService {
 
+    private final UserRepository userRepository;
     private final PostRepository postRepository;
 
+    @Transactional
+    public PostResponse createPost(Long userId, PostRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Post post = PostMapper.toEntity(request);
+        post.assignUser(user);
+        Post savedPost = postRepository.save(post);
+
+        return PostMapper.toResponse(savedPost);
+    }
 }

--- a/back/src/main/java/com/back/domain/post/service/PostService.java
+++ b/back/src/main/java/com/back/domain/post/service/PostService.java
@@ -54,4 +54,18 @@ public class PostService {
 
         return PostMapper.toResponseList(posts);
     }
+
+    @Transactional
+    public PostResponse updatePost(Long userId, Long postId, PostRequest request) {
+        return postRepository.findById(postId)
+                .map(post -> {
+                    if (!post.getUser().getId().equals(userId)) {
+                        throw new ApiException(ErrorCode.UNAUTHORIZED_USER);
+                    }
+                    post.updatePost(request.title(), request.content(), request.category());
+                    Post updatedPost = postRepository.save(post);
+                    return PostMapper.toResponse(updatedPost);
+                })
+                .orElseThrow(() -> new ApiException(ErrorCode.POST_NOT_FOUND));
+    }
 }

--- a/back/src/main/java/com/back/global/common/ApiResponse.java
+++ b/back/src/main/java/com/back/global/common/ApiResponse.java
@@ -1,0 +1,37 @@
+package com.back.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 공통 응답 형태
+ * {
+ *   "data": { ... },
+ *   "message": "성공적으로 조회되었습니다.",
+ *   "status": 200
+ * }
+ */
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final T data;
+    private final String message;
+    private final int status;
+
+    private ApiResponse(T data, String message, int status) {
+        this.data = data;
+        this.message = message;
+        this.status = status;
+    }
+
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return new ApiResponse<>(data, message, HttpStatus.OK.value());
+    }
+
+    public static <T> ApiResponse<T> success(T data, String message, HttpStatus status) {
+        return new ApiResponse<>(data, message, status.value());
+    }
+}

--- a/back/src/main/java/com/back/global/common/PageResponse.java
+++ b/back/src/main/java/com/back/global/common/PageResponse.java
@@ -1,0 +1,29 @@
+package com.back.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PageResponse<T> {
+    private List<T> items;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    public static <T> PageResponse<T> of(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber() + 1, // 응답도 1페이지 시작으로 반환, Page 객체는 0페이지부터 시작
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}

--- a/back/src/main/java/com/back/global/config/WebConfig.java
+++ b/back/src/main/java/com/back/global/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.back.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
+
+/**
+ * 웹 관련 설정을 정의하는 구성 클래스.
+ */
+@Configuration
+public class WebConfig {
+
+    // 스프링의 페이지 요청을 1부터 시작하도록 설정
+    // 최대 페이지 크기 및 기본 페이지 설정
+    @Bean
+    public PageableHandlerMethodArgumentResolverCustomizer customizer() {
+        return pageableResolver -> {
+            pageableResolver.setOneIndexedParameters(true); // page 요청이 1로 오면 0으로 인식
+            pageableResolver.setMaxPageSize(50);
+            pageableResolver.setFallbackPageable(PageRequest.of(0, 5));
+        };
+    }
+}

--- a/back/src/test/java/com/back/domain/post/controller/PostControllerTest.java
+++ b/back/src/test/java/com/back/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,106 @@
+package com.back.domain.post.controller;
+
+import com.back.domain.post.dto.PostRequest;
+import com.back.domain.post.entity.Post;
+import com.back.domain.post.enums.PostCategory;
+import com.back.domain.post.repository.PostRepository;
+import com.back.domain.user.entity.Gender;
+import com.back.domain.user.entity.Mbti;
+import com.back.domain.user.entity.Role;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        User testUser = User.builder()
+                .loginId("testLoginId")
+                .email("test@example.com")
+                .password("testPassword")
+                .beliefs("도전")
+                .gender(Gender.M)
+                .role(Role.USER)
+                .mbti(Mbti.ISFJ)
+                .birthdayAt(LocalDateTime.of(2000, 3, 1, 0, 0))
+                .build();
+        userRepository.save(testUser);
+    }
+
+    @Nested
+    @DisplayName("게시글 생성")
+    class CreatePost {
+
+        @Test
+        @DisplayName("성공 - 정상 요청")
+        void success() throws Exception {
+            // given
+            PostRequest request = new PostRequest("테스트 게시글", "테스트 내용입니다.", PostCategory.CHAT);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/posts")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.title").value("테스트 게시글"))
+                    .andExpect(jsonPath("$.content").value("테스트 내용입니다."))
+                    .andExpect(jsonPath("$.category").value("CHAT"));
+
+            Post savedPost = postRepository.findAll().get(0);
+            assertThat(savedPost.getTitle()).isEqualTo("테스트 게시글");
+            assertThat(savedPost.getContent()).isEqualTo("테스트 내용입니다.");
+            assertThat(savedPost.getCategory()).isEqualTo(PostCategory.CHAT);
+        }
+
+        @Test
+        @DisplayName("실패 - 유효성 검사 실패")
+        void fail_ValidationError() throws Exception {
+            // given
+            PostRequest request = new PostRequest("", "테스트 내용입니다.", PostCategory.CHAT);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/posts")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()))
+                    .andExpect(jsonPath("$.message").exists());
+        }
+    }
+}

--- a/back/src/test/java/com/back/domain/post/controller/PostControllerTest.java
+++ b/back/src/test/java/com/back/domain/post/controller/PostControllerTest.java
@@ -1,6 +1,7 @@
 package com.back.domain.post.controller;
 
 import com.back.domain.post.dto.PostRequest;
+import com.back.domain.post.dto.PostResponse;
 import com.back.domain.post.entity.Post;
 import com.back.domain.post.enums.PostCategory;
 import com.back.domain.post.repository.PostRepository;
@@ -18,14 +19,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -61,6 +66,17 @@ class PostControllerTest {
                 .birthdayAt(LocalDateTime.of(2000, 3, 1, 0, 0))
                 .build();
         userRepository.save(testUser);
+
+        IntStream.rangeClosed(1, 5).forEach(i -> {
+            postRepository.save(
+                    Post.builder()
+                            .title("목록 게시글 " + i)
+                            .content("목록 내용 " + i)
+                            .category(PostCategory.CHAT)
+                            .user(testUser)
+                            .build()
+            );
+        });
     }
 
     @Nested
@@ -73,16 +89,20 @@ class PostControllerTest {
             // given
             PostRequest request = new PostRequest("테스트 게시글", "테스트 내용입니다.", PostCategory.CHAT);
 
-            // when & then
-            mockMvc.perform(post("/api/v1/posts")
+            // when
+            MvcResult result = mockMvc.perform(post("/api/v1/posts")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.title").value("테스트 게시글"))
                     .andExpect(jsonPath("$.content").value("테스트 내용입니다."))
-                    .andExpect(jsonPath("$.category").value("CHAT"));
+                    .andExpect(jsonPath("$.category").value("CHAT"))
+                    .andReturn();
 
-            Post savedPost = postRepository.findAll().get(0);
+            String responseBody = result.getResponse().getContentAsString();
+            PostResponse response = objectMapper.readValue(responseBody, PostResponse.class);
+
+            Post savedPost = postRepository.findById(response.id()).orElseThrow();
             assertThat(savedPost.getTitle()).isEqualTo("테스트 게시글");
             assertThat(savedPost.getContent()).isEqualTo("테스트 내용입니다.");
             assertThat(savedPost.getCategory()).isEqualTo(PostCategory.CHAT);
@@ -101,6 +121,60 @@ class PostControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()))
                     .andExpect(jsonPath("$.message").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 조회")
+    class GetPost {
+
+        @Test
+        @DisplayName("성공 - 존재하는 게시글 조회")
+        void success() throws Exception {
+            // given
+            Post savedPost = postRepository.save(
+                    Post.builder()
+                            .title("조회 테스트 게시글")
+                            .content("조회 테스트 내용입니다.")
+                            .category(PostCategory.CHAT)
+                            .user(userRepository.findAll().get(0))
+                            .build()
+            );
+
+            // when & then
+            mockMvc.perform(get("/api/v1/posts/{postId}", savedPost.getId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.title").value("조회 테스트 게시글"))
+                    .andExpect(jsonPath("$.content").value("조회 테스트 내용입니다."))
+                    .andExpect(jsonPath("$.category").value("CHAT"));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 게시글 ID")
+        void fail_NotFound() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/v1/posts/{postId}", 9999L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.POST_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND.getMessage()))
+                    .andExpect(jsonPath("$.path").value("/api/v1/posts/9999"));
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 목록 조회")
+    class GetPosts {
+
+        @Test
+        @DisplayName("성공 - 게시글 목록 조회")
+        void success() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/v1/posts"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.length()").value(5))
+                    .andExpect(jsonPath("$[0].title").value("목록 게시글 1"))
+                    .andExpect(jsonPath("$[1].title").value("목록 게시글 2"));
         }
     }
 }


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**: 
1. 잡담 게시판 기본 CRUD와 테스트를 구현하였습니다.
2. API, Paging 공통 응답을 정의하였습니다.
3. Post 엔티티의 voteContent 컬럼의 타입을 jsonb에서 String 으로 변경하였습니다.
- **왜(Why)**: 
1. 게시판의 기본 기능을 제공하기 위해 CRUD와 테스트를 먼저 구현하였습니다.
2. API 응답 형식을 통일하고, 페이징 응답을 재사용 가능하게 하여 유지보수성을 높이기 위함입니다.
3. 개발 환경은 h2를 사용하므로 jsonb 타입을 지원하지 않기에 단순 문자열로 처리하였습니다.

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- 잡담 게시판 기본 CRUD 구현 및 단위 테스트 추가
- 공통 API/Paging 응답 포맷 정의 (global 패키지 - ApiResponse, PageResponse)
- Post 엔티티 voteContent 컬럼 타입을 String으로 단순화

## 영향 범위
- [x] **API 변경**
- [x] **DB 마이그레이션**
- [ ] **Breaking Change**
- [ ] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->