### PR TITLE
[FEAT]: 결정라인 및 트리구조 조회 구현

### DIFF
--- a/back/src/main/java/com/back/domain/node/controller/BaseLineController.java
+++ b/back/src/main/java/com/back/domain/node/controller/BaseLineController.java
@@ -1,13 +1,12 @@
 /**
  * [API] BaseLine 전용 엔드포인트
  * - 라인 단위 일괄 생성 / 중간 분기점(pivot) 조회
+ * - 전체 노드 목록 조회 / 단일 노드 조회
+ * - 사용자 전체 트리 조회 (베이스/결정 노드 일괄 반환)
  */
 package com.back.domain.node.controller;
 
-import com.back.domain.node.dto.BaseLineBulkCreateRequest;
-import com.back.domain.node.dto.BaseLineBulkCreateResponse;
-import com.back.domain.node.dto.BaseNodeDto;
-import com.back.domain.node.dto.PivotListDto;
+import com.back.domain.node.dto.*;
 import com.back.domain.node.service.NodeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -45,5 +44,13 @@ public class BaseLineController {
     @GetMapping("/nodes/{baseNodeId}")
     public ResponseEntity<BaseNodeDto> getBaseNode(@PathVariable Long baseNodeId) {
         return ResponseEntity.ok(nodeService.getBaseNode(baseNodeId));
+    }
+
+    // 사용자 전체 트리 조회 (베이스/결정 노드 일괄 반환)
+    @GetMapping("/{baseLineId}/tree")
+    public ResponseEntity<TreeDto> getTreeForBaseLine(@PathVariable Long baseLineId) {
+        // 트리 조회 서비스 호출
+        TreeDto tree = nodeService.getTreeForBaseLine(baseLineId);
+        return ResponseEntity.ok(tree);
     }
 }

--- a/back/src/main/java/com/back/domain/node/controller/DecisionLineController.java
+++ b/back/src/main/java/com/back/domain/node/controller/DecisionLineController.java
@@ -1,0 +1,33 @@
+/**
+ * [API] DecisionLine 조회 전용 컨트롤러
+ * - 목록: 사용자별 라인 요약
+ * - 상세: 라인 메타 + 노드 목록
+ */
+package com.back.domain.node.controller;
+
+import com.back.domain.node.dto.DecisionLineDetailDto;
+import com.back.domain.node.dto.DecisionLineListDto;
+import com.back.domain.node.service.NodeQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/decision-lines")
+@RequiredArgsConstructor
+public class DecisionLineController {
+
+    private final NodeQueryService nodeQueryService;
+
+    // 가장 중요한: 사용자별 결정 라인 목록(요약)
+    @GetMapping
+    public ResponseEntity<DecisionLineListDto> list(@RequestParam Long userId) {
+        return ResponseEntity.ok(nodeQueryService.getDecisionLines(userId));
+    }
+
+    // 가장 많이 사용하는: 특정 결정 라인 상세
+    @GetMapping("/{decisionLineId}")
+    public ResponseEntity<DecisionLineDetailDto> detail(@PathVariable Long decisionLineId) {
+        return ResponseEntity.ok(nodeQueryService.getDecisionLineDetail(decisionLineId));
+    }
+}

--- a/back/src/main/java/com/back/domain/node/dto/DecisionLineDetailDto.java
+++ b/back/src/main/java/com/back/domain/node/dto/DecisionLineDetailDto.java
@@ -1,0 +1,16 @@
+/**
+ * [DTO-RES] 결정 라인 상세(라인 메타 + 노드 목록)
+ * - nodes는 시간축(ageYear asc)으로 정렬
+ */
+package com.back.domain.node.dto;
+
+import com.back.domain.node.entity.DecisionLineStatus;
+import java.util.List;
+
+public record DecisionLineDetailDto(
+        Long decisionLineId,
+        Long userId,
+        Long baseLineId,
+        DecisionLineStatus status,
+        List<DecLineDto> nodes
+) {}

--- a/back/src/main/java/com/back/domain/node/dto/DecisionLineListDto.java
+++ b/back/src/main/java/com/back/domain/node/dto/DecisionLineListDto.java
@@ -1,0 +1,22 @@
+/**
+ * [DTO-RES] 결정 라인 목록(요약) 응답
+ */
+package com.back.domain.node.dto;
+
+import com.back.domain.node.entity.DecisionLineStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DecisionLineListDto(
+        List<LineSummary> lines
+) {
+    public record LineSummary(
+            Long decisionLineId,
+            Long baseLineId,
+            DecisionLineStatus status,
+            Integer nodeCount,
+            Integer firstAge,
+            Integer lastAge,
+            LocalDateTime createdAt
+    ) {}
+}

--- a/back/src/main/java/com/back/domain/node/dto/TreeDto.java
+++ b/back/src/main/java/com/back/domain/node/dto/TreeDto.java
@@ -1,5 +1,9 @@
 /**
  * [DTO] 트리 전체 조회 응답 모델 (Base/Decision 분리 리스트)
+ *
+ * 흐름 요약
+ * - baseNodes : 사용자 소유 BaseNode 전부를 ageYear asc, id asc로 정렬해 반환
+ * - decisionNodes : 사용자 소유 모든 DecisionLine의 노드를 라인별 정렬 조회 후 평탄화하여 반환
  */
 package com.back.domain.node.dto;
 

--- a/back/src/main/java/com/back/domain/node/repository/DecisionLineRepository.java
+++ b/back/src/main/java/com/back/domain/node/repository/DecisionLineRepository.java
@@ -13,4 +13,5 @@ import java.util.List;
 @Repository
 public interface DecisionLineRepository extends JpaRepository<DecisionLine, Long> {
     List<DecisionLine> findByUser(User user);
+    List<DecisionLine> findByBaseLine_Id(Long baseLineId);
 }

--- a/back/src/main/java/com/back/domain/node/repository/DecisionNodeRepository.java
+++ b/back/src/main/java/com/back/domain/node/repository/DecisionNodeRepository.java
@@ -1,12 +1,17 @@
+/**
+ * 결정 노드 엔티티에 대한 데이터베이스 접근을 담당하는 JpaRepository.
+ */
 package com.back.domain.node.repository;
 
 import com.back.domain.node.entity.DecisionNode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-/**
- * 결정 노드 엔티티에 대한 데이터베이스 접근을 담당하는 JpaRepository.
- */
+import java.util.List;
+
 @Repository
 public interface DecisionNodeRepository extends JpaRepository<DecisionNode, Long> {
+
+    // 라인별 노드 리스트(나이 ASC, id ASC) — 라인 상세용
+    List<DecisionNode> findByDecisionLine_IdOrderByAgeYearAscIdAsc(Long decisionLineId);
 }

--- a/back/src/main/java/com/back/domain/node/service/NodeQueryService.java
+++ b/back/src/main/java/com/back/domain/node/service/NodeQueryService.java
@@ -1,53 +1,66 @@
 /**
- * NodeQueryService
- * - 트리 조회, 라인 노드 목록, 단건 노드 조회(읽기 전용)
+ * [QUERY SERVICE] NodeQueryService — 읽기 전용 조회 파사드
+ *
+ * 흐름 요약
+ * - getTreeInfo(userId): 사용자 검증 → BaseNode 전량 조회·정렬 → 각 DecisionLine 노드를 정렬 조회 → DTO 매핑 후 합쳐서 TreeDto 반환
+ * - getBaseLineNodes(baseLineId): 라인 존재성 보장 → 정렬된 BaseNode 목록 DTO로 반환
+ * - getBaseNode(baseNodeId): 단건 조회 → DTO 매핑
+ * - getDecisionLines(userId), getDecisionLineDetail(decisionLineId): 메타/상세 조회(기존 로직 유지)
  */
 package com.back.domain.node.service;
 
-import com.back.domain.node.dto.BaseNodeDto;
-import com.back.domain.node.dto.DecLineDto;
-import com.back.domain.node.dto.TreeDto;
+import com.back.domain.node.dto.*;
 import com.back.domain.node.entity.BaseNode;
 import com.back.domain.node.entity.DecisionLine;
 import com.back.domain.node.entity.DecisionNode;
 import com.back.domain.node.mapper.NodeMappers;
 import com.back.domain.node.repository.BaseNodeRepository;
 import com.back.domain.node.repository.DecisionLineRepository;
+import com.back.domain.node.repository.DecisionNodeRepository;
 import com.back.domain.user.entity.User;
 import com.back.domain.user.repository.UserRepository;
 import com.back.global.exception.ApiException;
 import com.back.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-class NodeQueryService {
+@Transactional(readOnly = true)
+public class NodeQueryService {
 
     private final UserRepository userRepository;
     private final BaseNodeRepository baseNodeRepository;
+    private final DecisionNodeRepository decisionNodeRepository;
     private final DecisionLineRepository decisionLineRepository;
     private final NodeDomainSupport support;
 
-    // 가장 중요한: 트리 전체 조회
-    public TreeDto getTreeInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND, "User not found: " + userId));
+    // 가장 중요한: 특정 BaseLine 전체 트리 조회
+    public TreeDto getTreeForBaseLine(Long baseLineId) {
+        support.ensureBaseLineExists(baseLineId);
 
-        List<BaseNodeDto> baseDtos = new ArrayList<>();
-        for (BaseNode n : baseNodeRepository.findByUser(user)) baseDtos.add(NodeMappers.BASE_READ.map(n));
+        List<BaseNode> orderedBase = support.getOrderedBaseNodes(baseLineId);
+        List<BaseNodeDto> baseDtos = new ArrayList<>(orderedBase.size());
+        for (BaseNode n : orderedBase) baseDtos.add(NodeMappers.BASE_READ.map(n));
+
+        List<DecisionLine> lines = decisionLineRepository.findByBaseLine_Id(baseLineId);
 
         List<DecLineDto> decDtos = new ArrayList<>();
-        for (DecisionLine line : decisionLineRepository.findByUser(user))
-            for (DecisionNode dn : line.getDecisionNodes()) decDtos.add(NodeMappers.DECISION_READ.map(dn));
+        for (DecisionLine line : lines) {
+            List<DecisionNode> ordered = decisionNodeRepository
+                    .findByDecisionLine_IdOrderByAgeYearAscIdAsc(line.getId());
+            for (DecisionNode dn : ordered) decDtos.add(NodeMappers.DECISION_READ.map(dn));
+        }
 
         return new TreeDto(baseDtos, decDtos);
     }
 
-    // 가장 많이 사용하는: BaseLine 노드 정렬 조회(나이 asc)
+    // 라인별 베이스 노드를 정렬하여 반환
     public List<BaseNodeDto> getBaseLineNodes(Long baseLineId) {
         support.ensureBaseLineExists(baseLineId);
         List<BaseNode> nodes = baseNodeRepository.findByBaseLine_IdOrderByAgeYearAscIdAsc(baseLineId);
@@ -57,10 +70,57 @@ class NodeQueryService {
         return result;
     }
 
-    // 가장 많이 사용하는: BaseNode 단건 조회
+    // BaseNode 단건 조회
     public BaseNodeDto getBaseNode(Long baseNodeId) {
         BaseNode node = baseNodeRepository.findById(baseNodeId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NODE_NOT_FOUND, "BaseNode not found: " + baseNodeId));
         return NodeMappers.BASE_READ.map(node);
+    }
+
+    // 사용자별 결정 라인 요약 조회
+    public DecisionLineListDto getDecisionLines(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND, "User not found: " + userId));
+
+        List<DecisionLine> lines = decisionLineRepository.findByUser(user);
+        List<DecisionLineListDto.LineSummary> summaries = new ArrayList<>(lines.size());
+
+        for (DecisionLine line : lines) {
+            List<DecisionNode> nodes = line.getDecisionNodes();
+            nodes.sort(Comparator.comparingInt(DecisionNode::getAgeYear).thenComparing(DecisionNode::getId));
+
+            Integer nodeCount = nodes.size();
+            Integer firstAge = nodeCount > 0 ? nodes.get(0).getAgeYear() : null;
+            Integer lastAge  = nodeCount > 0 ? nodes.get(nodeCount - 1).getAgeYear() : null;
+
+            summaries.add(new DecisionLineListDto.LineSummary(
+                    line.getId(),
+                    line.getBaseLine().getId(),
+                    line.getStatus(),
+                    nodeCount,
+                    firstAge,
+                    lastAge,
+                    line.getCreatedDate()
+            ));
+        }
+        return new DecisionLineListDto(summaries);
+    }
+
+    // 특정 결정 라인의 상세(정렬된 노드 포함)
+    public DecisionLineDetailDto getDecisionLineDetail(Long decisionLineId) {
+        DecisionLine line = decisionLineRepository.findById(decisionLineId)
+                .orElseThrow(() -> new ApiException(ErrorCode.DECISION_LINE_NOT_FOUND, "DecisionLine not found: " + decisionLineId));
+
+        List<DecisionNode> nodes = decisionNodeRepository.findByDecisionLine_IdOrderByAgeYearAscIdAsc(decisionLineId);
+        List<DecLineDto> nodeDtos = new ArrayList<>(nodes.size());
+        for (DecisionNode n : nodes) nodeDtos.add(NodeMappers.DECISION_READ.map(n));
+
+        return new DecisionLineDetailDto(
+                line.getId(),
+                line.getUser().getId(),
+                line.getBaseLine().getId(),
+                line.getStatus(),
+                nodeDtos
+        );
     }
 }

--- a/back/src/main/java/com/back/domain/node/service/NodeService.java
+++ b/back/src/main/java/com/back/domain/node/service/NodeService.java
@@ -22,8 +22,8 @@ public class NodeService {
     private final NodeQueryService nodeQueryService;
 
     // 트리 전체 조회 위임
-    public TreeDto getTreeInfo(Long userId) {
-        return nodeQueryService.getTreeInfo(userId);
+    public TreeDto getTreeForBaseLine(Long baseLineId) {
+        return nodeQueryService.getTreeForBaseLine(baseLineId);
     }
 
     // BaseLine 일괄 생성 위임

--- a/back/src/test/java/com/back/domain/node/controller/DecisionLineControllerTest.java
+++ b/back/src/test/java/com/back/domain/node/controller/DecisionLineControllerTest.java
@@ -1,0 +1,419 @@
+/**
+ * [TEST SUITE] Re:Life — DecisionLine 조회(목록·상세) 통합 테스트
+ *
+ * 목적
+ * - /api/v1/decision-lines?userId=... : 사용자별 결정 라인 목록(요약) 조회 검증
+ * - /api/v1/decision-lines/{id}      : 특정 결정 라인 상세(노드 타임라인) 조회 검증
+ * - 성공/실패(존재하지 않는 라인) 분류별로 정리
+ *
+ * 주석 규칙
+ * 1) 파일 최상단 요약 주석(본 블록)
+ * 2) 가장 중요한 함수 위 한 줄 요약 주석
+ * 3) 가장 많이 사용하는 함수/헬퍼 위 한 줄 요약 주석
+ */
+package com.back.domain.node.controller;
+
+import com.back.domain.node.entity.NodeCategory;
+import com.back.domain.user.entity.*;
+import com.back.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Re:Life — DecisionLine 조회(목록·상세) 통합 테스트")
+public class DecisionLineControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper om;
+    @Autowired private UserRepository userRepository;
+
+    private Long userId;
+
+    @BeforeAll
+    void initUser() {
+        String uid = UUID.randomUUID().toString().substring(0, 8);
+        User user = User.builder()
+                .loginId("login_" + uid)
+                .email("user_" + uid + "@test.local")
+                .role(Role.GUEST)
+                .birthdayAt(LocalDateTime.now().minusYears(25))
+                .gender(Gender.M)
+                .mbti(Mbti.INTJ)
+                .beliefs("NONE")
+                .authProvider(AuthProvider.GUEST)
+                .nickname("tester-" + uid)
+                .build();
+        userId = userRepository.save(user).getId();
+    }
+
+    // ===========================
+    // 목록 조회
+    // ===========================
+    @Nested
+    @DisplayName("결정 라인 목록 조회")
+    class ListLines {
+
+        @Test
+        @DisplayName("성공 : 한 사용자에 대해 2개 이상의 결정 라인이 생성되면 목록에 각각 요약으로 나타난다")
+        void success_listMultipleLines() throws Exception {
+            var lineA = startDecisionLine(userId, 0, new String[]{"A1","A2"}, 0);
+            var lineB = startDecisionLine(userId, 1, new String[]{"B1","B2"}, 1);
+
+            var res = mockMvc.perform(get("/api/v1/decision-lines")
+                            .param("userId", userId.toString()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.lines").isArray())
+                    .andReturn();
+
+            JsonNode body = om.readTree(res.getResponse().getContentAsString());
+            JsonNode lines = body.get("lines");
+            assertThat(lines.size()).isGreaterThanOrEqualTo(2);
+
+            JsonNode first = lines.get(0);
+            assertThat(first.get("decisionLineId").isNumber()).isTrue();
+            assertThat(first.get("baseLineId").isNumber()).isTrue();
+            assertThat(first.get("status").asText()).isIn("DRAFT", "COMPLETED", "CANCELLED");
+        }
+
+        @Test
+        @DisplayName("성공 : 결정 라인이 없으면 빈 배열을 반환한다")
+        void success_emptyListWhenNoLines() throws Exception {
+            String uid2 = UUID.randomUUID().toString().substring(0, 8);
+            Long newUserId = userRepository.save(User.builder()
+                            .loginId("login_" + uid2)
+                            .email("user_" + uid2 + "@test.local")
+                            .role(Role.GUEST)
+                            .birthdayAt(LocalDateTime.now().minusYears(23))
+                            .gender(Gender.F)
+                            .mbti(Mbti.ENFP)
+                            .beliefs("NONE")
+                            .authProvider(AuthProvider.GUEST)
+                            .nickname("tester2-" + uid2)
+                            .build())
+                    .getId();
+
+            var res = mockMvc.perform(get("/api/v1/decision-lines")
+                            .param("userId", newUserId.toString()))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            JsonNode lines = om.readTree(res.getResponse().getContentAsString()).get("lines");
+            assertThat(lines.isArray()).isTrue();
+            assertThat(lines.size()).isEqualTo(0);
+        }
+    }
+
+    // ===========================
+    // 상세 조회
+    // ===========================
+    @Nested
+    @DisplayName("결정 라인 상세 조회")
+    class DetailLine {
+
+        @Test
+        @DisplayName("성공 : 라인 상세는 라인 메타와 노드 배열을 ageYear 오름차순으로 반환한다")
+        void success_detailReturnsNodesSorted() throws Exception {
+            var head = startDecisionLine(userId, 0, new String[]{"선택A","선택B"}, 0);
+
+            // 가장 많이 사용하는: 다음 결정 1개 추가
+            appendNextDecision(head.headDecisionNodeId);
+
+            var res = mockMvc.perform(get("/api/v1/decision-lines/{id}", head.decisionLineId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.decisionLineId").value(head.decisionLineId))
+                    .andExpect(jsonPath("$.nodes").isArray())
+                    .andReturn();
+
+            JsonNode detail = om.readTree(res.getResponse().getContentAsString());
+            JsonNode nodes = detail.get("nodes");
+            assertThat(nodes.size()).isGreaterThanOrEqualTo(2);
+            int age0 = nodes.get(0).get("ageYear").asInt();
+            int age1 = nodes.get(1).get("ageYear").asInt();
+            assertThat(age1).isGreaterThan(age0);
+            assertThat(nodes.get(0).get("decisionLineId").asLong()).isEqualTo(head.decisionLineId);
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 decisionLineId 상세 조회 시 404/N003를 반환한다")
+        void fail_detailNotFound() throws Exception {
+            mockMvc.perform(get("/api/v1/decision-lines/{id}", 9_999_999L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("N003"))
+                    .andExpect(jsonPath("$.message").exists());
+        }
+    }
+
+    // ===========================
+    // 라인 분리/격리
+    // ===========================
+    @Nested
+    @DisplayName("라인 분리/격리")
+    class Separation {
+
+        @Test
+        @DisplayName("성공 : 같은 BaseLine의 같은 피벗에서 슬롯0/슬롯1로 시작하면 서로 다른 DecisionLine이 생성된다")
+        void success_separateLines_samePivot_diffSlots() throws Exception {
+            var base = createBaseLineAndGetPivot(userId, 0);
+            var dl1 = fromBaseStartOnExistingBaseLine(userId, base.baseLineId, base.pivotAge,
+                    0, new String[]{"A1"}, 0); // 슬롯0 — 단일 옵션
+            var dl2 = fromBaseStartOnExistingBaseLine(userId, base.baseLineId, base.pivotAge,
+                    1, new String[]{"B1"}, 0); // 슬롯1 — 단일 옵션
+
+            assertThat(dl1.decisionLineId).isNotEqualTo(dl2.decisionLineId);
+
+            var res = mockMvc.perform(get("/api/v1/decision-lines").param("userId", userId.toString()))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            JsonNode lines = om.readTree(res.getResponse().getContentAsString()).get("lines");
+            assertThat(lines.toString()).contains("\"decisionLineId\":" + dl1.decisionLineId);
+            assertThat(lines.toString()).contains("\"decisionLineId\":" + dl2.decisionLineId);
+
+            JsonNode d1 = getLineDetail(dl1.decisionLineId);
+            JsonNode d2 = getLineDetail(dl2.decisionLineId);
+            assertThat(d1.get("decisionLineId").asLong()).isEqualTo(dl1.decisionLineId);
+            assertThat(d2.get("decisionLineId").asLong()).isEqualTo(dl2.decisionLineId);
+            assertThat(d1.get("nodes").size()).isEqualTo(1);
+            assertThat(d2.get("nodes").size()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("실패 : 같은 BaseLine 같은 피벗 같은 슬롯으로 from-base 재시도시 이미 링크됨(C001)으로 거부된다")
+        void fail_sameSlotTwiceRejected_onSameBaseLine() throws Exception {
+            var base = createBaseLineAndGetPivot(userId, 0);
+
+            fromBaseStartOnExistingBaseLine(userId, base.baseLineId, base.pivotAge,
+                    0, new String[]{"A1"}, 0);
+
+            String again = """
+            {
+              "userId": %d,
+              "baseLineId": %d,
+              "pivotAge": %d,
+              "selectedAltIndex": 0,
+              "category": "%s",
+              "situation": "중복 시도",
+              "options": ["A1"],
+              "selectedIndex": 0
+            }
+            """.formatted(userId, base.baseLineId, base.pivotAge, NodeCategory.EDUCATION);
+
+            mockMvc.perform(post("/api/v1/decision-flow/from-base")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(again))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C001"));
+        }
+
+        @Test
+        @DisplayName("성공 : DL1에 next를 추가해도 DL2에는 영향이 없고 각 상세는 자신의 노드만 포함한다")
+        void success_nextAffectsOnlyOwnLine() throws Exception {
+            var base = createBaseLineAndGetPivot(userId, 0);
+            var dl1 = fromBaseStartOnExistingBaseLine(userId, base.baseLineId, base.pivotAge, 0, new String[]{"A1"}, 0);
+            var dl2 = fromBaseStartOnExistingBaseLine(userId, base.baseLineId, base.pivotAge, 1, new String[]{"B1"}, 0);
+
+            appendNextDecision(dl1.headDecisionNodeId);
+
+            JsonNode d1 = getLineDetail(dl1.decisionLineId);
+            JsonNode d2 = getLineDetail(dl2.decisionLineId);
+            assertThat(d1.get("nodes").size()).isGreaterThanOrEqualTo(2);
+            assertThat(d2.get("nodes").size()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("성공 : 같은 피벗에서 두 옵션을 동시에 정의해도 슬롯0/1 각각 다른 라인으로 생성된다")
+        void success_separateLines_samePivot_withTwoOptionsOnBothCalls() throws Exception {
+            // 같은 BaseLine, 같은 pivotAge 기준
+            var base = createBaseLineAndGetPivot(userId, 0);
+
+            // 첫 호출: 옵션 ["A1","A2"] 정의 + 슬롯0 선택(= altOpt1 링크)
+            var dl1 = fromBaseStartOnExistingBaseLine(
+                    userId, base.baseLineId, base.pivotAge,
+                    0, new String[]{"A1","A2"}, 0
+            );
+
+            // 두 번째 호출: 같은 옵션 텍스트 유지 + 슬롯1 선택(= altOpt2 링크)
+            var dl2 = fromBaseStartOnExistingBaseLine(
+                    userId, base.baseLineId, base.pivotAge,
+                    1, new String[]{"A1","A2"}, 1
+            );
+
+            // 서로 다른 라인으로 생성
+            assertThat(dl1.decisionLineId).isNotEqualTo(dl2.decisionLineId);
+
+            // 상세 각각 1개 노드(헤드)만 포함
+            JsonNode d1 = getLineDetail(dl1.decisionLineId);
+            JsonNode d2 = getLineDetail(dl2.decisionLineId);
+            assertThat(d1.get("nodes").size()).isEqualTo(1);
+            assertThat(d2.get("nodes").size()).isEqualTo(1);
+
+            // 한쪽에 next 추가해도 다른 쪽엔 영향 없음
+            appendNextDecision(dl1.headDecisionNodeId);
+            d1 = getLineDetail(dl1.decisionLineId);
+            d2 = getLineDetail(dl2.decisionLineId);
+            assertThat(d1.get("nodes").size()).isGreaterThanOrEqualTo(2);
+            assertThat(d2.get("nodes").size()).isEqualTo(1);
+        }
+
+    }
+
+    // ===========================
+    // 헬퍼
+    // ===========================
+
+    // 가장 중요한: 베이스라인 생성 → 피벗 선택(pivotOrd) → from-base로 첫 결정 생성
+    private HeadLine startDecisionLine(Long uid, int pivotOrd, String[] options2, int selectedIdx) throws Exception {
+        var createRes = mockMvc.perform(post("/api/v1/base-lines/bulk")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(sampleLineJson(uid)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        long baseLineId = om.readTree(createRes.getResponse().getContentAsString()).get("baseLineId").asLong();
+
+        var pivotsRes = mockMvc.perform(get("/api/v1/base-lines/{id}/pivots", baseLineId))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode pivots = om.readTree(pivotsRes.getResponse().getContentAsString()).get("pivots");
+        int pivotAge = pivots.get(pivotOrd).get("ageYear").asInt();
+
+        String optionsJson = toJsonArray(options2);
+        String fromBaseReq = """
+        {
+          "userId": %d,
+          "baseLineId": %d,
+          "pivotAge": %d,
+          "selectedAltIndex": %d,
+          "category": "%s",
+          "situation": "피벗에서 첫 결정",
+          "options": %s,
+          "selectedIndex": %d
+        }
+        """.formatted(uid, baseLineId, pivotAge, selectedIdx, NodeCategory.EDUCATION, optionsJson, selectedIdx);
+
+        var fromBaseRes = mockMvc.perform(post("/api/v1/decision-flow/from-base")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(fromBaseReq))
+                .andExpect(status().isCreated())
+                .andReturn();
+        JsonNode head = om.readTree(fromBaseRes.getResponse().getContentAsString());
+        long decisionLineId = head.get("decisionLineId").asLong();
+        long headDecisionNodeId = head.get("id").asLong();
+
+        return new HeadLine(decisionLineId, headDecisionNodeId, pivotAge);
+    }
+
+    // 가장 많이 사용하는: 기존 BaseLine·pivotAge에서 from-base로 1회 시작
+    private HeadLine fromBaseStartOnExistingBaseLine(Long uid, long baseLineId, int pivotAge,
+                                                     int selectedAltIndex, String[] options, int selectedIndex) throws Exception {
+        String optionsJson = toJsonArray(options);
+        String req = """
+        {
+          "userId": %d,
+          "baseLineId": %d,
+          "pivotAge": %d,
+          "selectedAltIndex": %d,
+          "category": "%s",
+          "situation": "피벗에서 첫 결정",
+          "options": %s,
+          "selectedIndex": %d
+        }
+        """.formatted(uid, baseLineId, pivotAge, selectedAltIndex, NodeCategory.EDUCATION, optionsJson, selectedIndex);
+
+        var res = mockMvc.perform(post("/api/v1/decision-flow/from-base")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(req))
+                .andExpect(status().isCreated())
+                .andReturn();
+        JsonNode head = om.readTree(res.getResponse().getContentAsString());
+        return new HeadLine(head.get("decisionLineId").asLong(), head.get("id").asLong(), head.get("ageYear").asInt());
+    }
+
+    // 가장 많이 사용하는: 다음 결정 1개 추가(next) — 자동 다음 피벗
+    private void appendNextDecision(long parentDecisionNodeId) throws Exception {
+        String nextReq = """
+        {
+          "userId": %d,
+          "parentDecisionNodeId": %d,
+          "category": "%s",
+          "situation": "다음 선택",
+          "options": ["수락","보류","거절"],
+          "selectedIndex": 0
+        }
+        """.formatted(userId, parentDecisionNodeId, NodeCategory.CAREER);
+
+        mockMvc.perform(post("/api/v1/decision-flow/next")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(nextReq))
+                .andExpect(status().isCreated());
+    }
+
+    // 가장 많이 사용하는: 라인 상세 조회(JSON)
+    private JsonNode getLineDetail(long decisionLineId) throws Exception {
+        var res = mockMvc.perform(get("/api/v1/decision-lines/{id}", decisionLineId))
+                .andExpect(status().isOk())
+                .andReturn();
+        return om.readTree(res.getResponse().getContentAsString());
+    }
+
+    // (헬퍼) 문자열 배열을 JSON 배열로 직렬화
+    private String toJsonArray(String[] arr) {
+        if (arr == null || arr.length == 0) return "[]";
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < arr.length; i++) {
+            if (i > 0) sb.append(',');
+            sb.append('"').append(arr[i].replace("\"","\\\"")).append('"');
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    // 베이스라인 샘플 입력 — fixedChoice=decision 채워 유효성 통과
+    private String sampleLineJson(Long uid) {
+        return """
+        { "userId": %d,
+          "nodes": [
+            {"category":"%s","situation":"고등학교 졸업","decision":"고등학교 졸업","ageYear":18},
+            {"category":"%s","situation":"대학 입학","decision":"대학 입학","ageYear":20},
+            {"category":"%s","situation":"첫 인턴","decision":"첫 인턴","ageYear":22},
+            {"category":"%s","situation":"결말","decision":"결말","ageYear":24}
+          ]
+        }
+        """.formatted(uid,
+                NodeCategory.EDUCATION, NodeCategory.EDUCATION, NodeCategory.CAREER, NodeCategory.ETC);
+    }
+    // 주어진 pivotOrd의 age와 baseLineId를 반환
+    private BaseInfo createBaseLineAndGetPivot(Long uid, int pivotOrd) throws Exception {
+        var res = mockMvc.perform(post("/api/v1/base-lines/bulk")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(sampleLineJson(uid)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        long baseLineId = om.readTree(res.getResponse().getContentAsString()).get("baseLineId").asLong();
+
+        var pivotsRes = mockMvc.perform(get("/api/v1/base-lines/{id}/pivots", baseLineId))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode pivots = om.readTree(pivotsRes.getResponse().getContentAsString()).get("pivots");
+        int pivotAge = pivots.get(pivotOrd).get("ageYear").asInt();
+
+        return new BaseInfo(baseLineId, pivotAge);
+    }
+
+    // DTOs
+    private record HeadLine(long decisionLineId, long headDecisionNodeId, int ageYear) {}
+    private record BaseInfo(long baseLineId, int pivotAge) {}
+}


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**:
1. 트리구조 구현
2. 결정라인에 따른 각 라인만 조회기능
- **왜(Why)**:
1. 전체 베이스라인에 속한 트리구조를 전체적으로 보기 위함
2. 결정 라인에 따른 각 라인을 조회해서 시나리오와 연계하기 위함

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
-  베이스 라인 하나에 속한 모든 노드 출력 및 결정 라인에 따른 각 노드 출력

## 영향 범위
- [x] **API 변경**
- [ ] **DB 마이그레이션**
- [ ] **Breaking Change**
- [ ] **보안/권한 영향**
- [x] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #31
<!-- auto-linked-issue:31 -->