### PR TITLE
[FEAT]: Redis 기반 세션 스토어 전환

### DIFF
--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation ("org.springframework.session:spring-session-data-redis")
 
     // Session
     implementation("org.springframework.session:spring-session-data-redis")

--- a/back/src/main/resources/application-test.yml
+++ b/back/src/main/resources/application-test.yml
@@ -1,4 +1,10 @@
 spring:
+  session:
+    store-type: redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
   datasource:
     url: jdbc:h2:mem:db_test;MODE=PostgreSQL;
     username: sa

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -1,10 +1,10 @@
 spring:
   application:
     name: back
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-      - org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
+  #autoconfigure:
+  #  exclude:
+   #  - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+   #  - org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
   config:
     import: optional:file:.env[.properties]
   flyway:


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**: 메모리 기반 세션 저장소를 Redis로 전환
- **왜(Why)**: 

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- Spring Session Data Redis 의존성 추가 및 Redis 연결 설정
- 기존 세션 자동 설정 제외(exclude) 주석 처하여 Redis 세션 정상 작동
- 테스트 코드를 Redis 세션 환경에 맞게 수정 (MockHttpSession → JSESSIONID 쿠키 기반)

## 영향 범위
- [ ] **API 변경**
- [ ] **DB 마이그레이션**
- [ ] **Breaking Change**
- [x] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [ ] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->
### Redis에 세션 저장 확인
127.0.0.1:6379> keys *
1) "spring:session:sessions:950a4112-4d0a-45b7-bdd6-xxxxxxxxxxxx"

### TTL 확인 (30분 = 1800초)
127.0.0.1:6379> ttl spring:session:sessions:950a4112-4d0a-45b7-bdd6-xxxxxxxxxxxx
(integer) 1213
## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #82
<!-- auto-linked-issue:82 -->