### PR TITLE
[REFACTOR]: 시나리오 생성시 마지막 노드 & 트리구조 출력 변경

### DIFF
--- a/back/src/main/java/com/back/domain/node/dto/decision/DecNodeDto.java
+++ b/back/src/main/java/com/back/domain/node/dto/decision/DecNodeDto.java
@@ -1,12 +1,13 @@
 /**
- * [DTO-RES] DecisionNode 응답(보강)
- * - followPolicy/pinnedCommitId/virtual 플래그를 추가해 해석 상태를 노출
- * - effective* 필드는 Resolver가 계산한 최종 표현값(렌더 우선 사용)
+ * [DTO-RES] DecisionNode 응답(보강 최종본)
+ * - 정책/핀/가상(followPolicy/pinnedCommitId/virtual)과 effective* 해석값 노출
+ * - 렌더 편의: childrenIds/root/pivot 링크 + 단일 패스 렌더용 힌트(renderPhase, incoming*)
  */
 package com.back.domain.node.dto.decision;
 
 import com.back.domain.node.entity.FollowPolicy;
 import com.back.domain.node.entity.NodeCategory;
+
 import java.util.List;
 
 public record DecNodeDto(
@@ -40,10 +41,16 @@ public record DecNodeDto(
         List<String> effectiveOptions,
         String effectiveDescription,
 
+        // 기본 렌더 편의
         List<Long> childrenIds,        // 이 DECISION의 자식들 id(시간순)
         Boolean root,                  // 라인 헤더면 true
         Long pivotLinkBaseNodeId,      // 베이스 분기 슬롯에서 올라온 첫 노드면 해당 BaseNode id
-        Integer pivotSlotIndex         // 0/1 (분기 슬롯 인덱스), 아니면 null
+        Integer pivotSlotIndex,        // 0/1 (분기 슬롯 인덱스), 아니면 null
+
+        // 단일 패스 렌더용 최소 힌트
+        Integer renderPhase,           // 1=from-base 라인, 2..N=fork 깊이(부모 라인 +1)
+        Long incomingFromId,           // 이 노드로 "들어오는" 에지의 from 노드 id(루트면 포크 원본, 아니면 parentId)
+        String incomingEdgeType        // "normal" | "fork"
 ) {
     // === 호환 오버로드(기존 서비스 호출 유지) ===
     public DecNodeDto(
@@ -62,7 +69,7 @@ public record DecNodeDto(
                 parentOptionIndex, description, aiNextSituation, aiNextRecommendedOption,
                 followPolicy, pinnedCommitId, virtual, effectiveCategory, effectiveSituation,
                 effectiveDecision, effectiveOptions, effectiveDescription,
-                null, null, null, null); // ← 새 필드는 null 기본값
+                null, null, null, null,
+                null, null, null); // 새 필드는 null 기본값
     }
-
 }

--- a/back/src/main/java/com/back/domain/node/service/DecisionFlowService.java
+++ b/back/src/main/java/com/back/domain/node/service/DecisionFlowService.java
@@ -311,7 +311,6 @@ public class DecisionFlowService {
     public DecisionLineLifecycleDto completeDecisionLine(Long decisionLineId) {
         DecisionLine line = support.requireDecisionLine(decisionLineId);
         try { line.complete(); } catch (RuntimeException e) { throw support.mapDomainToApi(e); }
-        decisionLineRepository.save(line);
         return new DecisionLineLifecycleDto(line.getId(), line.getStatus());
     }
 

--- a/back/src/main/java/com/back/domain/scenario/controller/ScenarioController.java
+++ b/back/src/main/java/com/back/domain/scenario/controller/ScenarioController.java
@@ -1,5 +1,6 @@
 package com.back.domain.scenario.controller;
 
+import com.back.domain.node.dto.decision.DecisionNodeNextRequest;
 import com.back.domain.scenario.dto.*;
 import com.back.domain.scenario.service.ScenarioService;
 import com.back.global.common.PageResponse;
@@ -42,12 +43,13 @@ public class ScenarioController {
     @PostMapping
     @Operation(summary = "시나리오 생성", description = "DecisionLine을 기반으로 AI 시나리오를 생성합니다.")
     public ResponseEntity<ScenarioStatusResponse> createScenario(
-            @Valid @RequestBody ScenarioCreateRequest request,
+            @Valid @RequestPart("scenario") ScenarioCreateRequest request,
+            @RequestPart(value = "lastDecision", required = false) DecisionNodeNextRequest lastDecision,
             @AuthenticationPrincipal CustomUserDetails userDetails
             ) {
         Long userId = getUserId(userDetails);
 
-        ScenarioStatusResponse scenarioCreateResponse = scenarioService.createScenario(userId, request);
+        ScenarioStatusResponse scenarioCreateResponse = scenarioService.createScenario(userId,request, lastDecision);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(scenarioCreateResponse);
     }

--- a/back/src/test/java/com/back/domain/scenario/service/ScenarioServiceTest.java
+++ b/back/src/test/java/com/back/domain/scenario/service/ScenarioServiceTest.java
@@ -92,7 +92,7 @@ class ScenarioServiceTest {
             doNothing().when(scenarioService).processScenarioGenerationAsync(anyLong());
 
             // When
-            ScenarioStatusResponse result = scenarioService.createScenario(userId, request);
+            ScenarioStatusResponse result = scenarioService.createScenario(userId, request, null);
 
             // Then - 시나리오 생성 요청이 접수되고 PENDING 상태로 반환되는지만 검증
             assertThat(result).isNotNull();
@@ -121,7 +121,7 @@ class ScenarioServiceTest {
                     .willReturn(Optional.empty());
 
             // When & Then
-            assertThatThrownBy(() -> scenarioService.createScenario(userId, request))
+            assertThatThrownBy(() -> scenarioService.createScenario(userId, request, null))
                     .isInstanceOf(ApiException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DECISION_LINE_NOT_FOUND);
 
@@ -150,7 +150,7 @@ class ScenarioServiceTest {
                     .willReturn(Optional.of(mockDecisionLine));
 
             // When & Then
-            assertThatThrownBy(() -> scenarioService.createScenario(userId, request))
+            assertThatThrownBy(() -> scenarioService.createScenario(userId, request, null))
                     .isInstanceOf(ApiException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.HANDLE_ACCESS_DENIED);
 
@@ -188,7 +188,7 @@ class ScenarioServiceTest {
                     .willReturn(Optional.of(existingScenario)); // 기존 PENDING 시나리오 존재
 
             // When & Then
-            assertThatThrownBy(() -> scenarioService.createScenario(userId, request))
+            assertThatThrownBy(() -> scenarioService.createScenario(userId, request, null))
                     .isInstanceOf(ApiException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SCENARIO_ALREADY_IN_PROGRESS);
 


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**: 
1. 시나리오 생성시 마지막 노드 저장과 동시에 시나리오 바로 생성
2. 트리구조 조회시 출력 형태를 정제된 트리구조로 변경
- **왜(Why)**:
1. api 2중 호출을 막기 위함
2. 트리구조 조회시 포크를 여러번 하는 경우 프론트에서의 연산이 계속 늘어나기 때문에 백엔드에서 연산 후 정제된 트리구조를 출력

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- nodenextRequestDto를 가져와서 사용, slack에 올린 사항대로 requestbody에서 requestpart로 변경
트리구조를 BFS로 정렬후 프론트에서 뽑아낼 힌트(fromnode의 id와 그 라인의 종류(normal / fork))를 담아서 보냄  

## 영향 범위
- [x] **API 변경**
- [ ] **DB 마이그레이션**
- [ ] **Breaking Change**
- [ ] **보안/권한 영향**
- [x] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #89
<!-- auto-linked-issue:89 -->