### PR TITLE
[FIX]: 이미지생성관련 배포실패버그수정

### DIFF
--- a/back/src/main/java/com/back/global/ai/client/image/NoOpImageAiClient.java
+++ b/back/src/main/java/com/back/global/ai/client/image/NoOpImageAiClient.java
@@ -1,0 +1,44 @@
+package com.back.global.ai.client.image;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * 이미지 AI 기능이 비활성화되었을 때 사용되는 NoOp 구현체.
+ * 실제 이미지를 생성하지 않고 placeholder URL을 반환합니다.
+ *
+ * 활성화 조건:
+ * - ai.image.enabled=false인 경우
+ * - STABILITY_API_KEY가 설정되지 않은 경우
+ * - S3 연결이 불가능한 프로덕션 환경
+ */
+@Slf4j
+@Component
+@ConditionalOnMissingBean(ImageAiClient.class)
+public class NoOpImageAiClient implements ImageAiClient {
+
+    public NoOpImageAiClient() {
+        log.info("NoOpImageAiClient initialized - Image generation is disabled");
+    }
+
+    @Override
+    public CompletableFuture<String> generateImage(String prompt) {
+        log.debug("Image generation disabled. Returning placeholder for prompt: {}", prompt);
+        return CompletableFuture.completedFuture("placeholder-image-url");
+    }
+
+    @Override
+    public CompletableFuture<String> generateImage(String prompt, Map<String, Object> options) {
+        log.debug("Image generation disabled. Returning placeholder for prompt: {}", prompt);
+        return CompletableFuture.completedFuture("placeholder-image-url");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**:
- NoOp구현체추가
- **왜(Why)**:
- 이미지생성비활성화시 배포실패를 방지하기위해서입니다.

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- 현재 AWS S3에 연결이 불완전하여 이미지생성기능을 비활성화했습니다. 이에 따라 이미지생성에 버그가 발생하여 배포가 실패하였고, 이를 해결하기위해 이미지생성기능이 비활성화된 상태에서 placeholder url을 반환하도록하여 이미지생성기능이 비활성화된 상태에서도 배포가 가능하도록 했습니다.

## 영향 범위
- [ ] **API 변경**
- [ ] **DB 마이그레이션**
- [x] **Breaking Change**
- [ ] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #103
<!-- auto-linked-issue:103 -->