### PR TITLE
[REFACTOR]: 트리구조용 시나리오Id조회 API추가

### DIFF
--- a/back/src/main/java/com/back/domain/scenario/controller/ScenarioController.java
+++ b/back/src/main/java/com/back/domain/scenario/controller/ScenarioController.java
@@ -89,6 +89,22 @@ public class ScenarioController {
         return ResponseEntity.ok(scenarioDetailResponse);
     }
 
+    @GetMapping("/by-decision-line/{decisionLineId}")
+    @Operation(
+        summary = "DecisionLine ID로 시나리오 조회",
+        description = "트리 시각화에서 DecisionLine ID를 통해 연결된 시나리오의 상세 정보를 조회합니다."
+    )
+    public ResponseEntity<ScenarioDetailResponse> getScenarioByDecisionLine(
+            @Parameter(description = "DecisionLine ID") @PathVariable Long decisionLineId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = getUserId(userDetails);
+
+        ScenarioDetailResponse scenarioDetailResponse = scenarioService.getScenarioByDecisionLine(decisionLineId, userId);
+
+        return ResponseEntity.ok(scenarioDetailResponse);
+    }
+
     @GetMapping("/{scenarioId}/timeline")
     @Operation(summary = "시나리오 타임라인 조회", description = "시나리오의 선택 경로를 시간순으로 조회합니다.")
     public ResponseEntity<TimelineResponse> getScenarioTimeline(

--- a/back/src/main/java/com/back/domain/scenario/repository/ScenarioRepository.java
+++ b/back/src/main/java/com/back/domain/scenario/repository/ScenarioRepository.java
@@ -32,6 +32,13 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long> {
     @Query("SELECT s FROM Scenario s WHERE s.decisionLine.id = :decisionLineId")
     Optional<Scenario> findByDecisionLineId(@Param("decisionLineId") Long decisionLineId);
 
+    // DecisionLine 기반 시나리오 조회 (권한 검증 포함)
+    @Query("SELECT s FROM Scenario s WHERE s.decisionLine.id = :decisionLineId AND s.user.id = :userId")
+    Optional<Scenario> findByDecisionLineIdAndUserId(
+        @Param("decisionLineId") Long decisionLineId,
+        @Param("userId") Long userId
+    );
+
     // 내 완료된 선택 시나리오 목록 조회 (베이스 시나리오 제외)
     Page<Scenario> findByUserIdAndDecisionLineIsNotNullAndStatusOrderByCreatedDateDesc(
             Long userId,

--- a/back/src/main/java/com/back/domain/scenario/service/ScenarioService.java
+++ b/back/src/main/java/com/back/domain/scenario/service/ScenarioService.java
@@ -423,6 +423,21 @@ public class ScenarioService {
         return ScenarioDetailResponse.from(scenario, sceneTypes);
     }
 
+    // DecisionLine ID로 시나리오 상세 조회
+    @Transactional(readOnly = true)
+    public ScenarioDetailResponse getScenarioByDecisionLine(Long decisionLineId, Long userId) {
+        // DecisionLine에 연결된 시나리오 조회 (권한 검증 포함)
+        Scenario scenario = scenarioRepository.findByDecisionLineIdAndUserId(decisionLineId, userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.SCENARIO_NOT_FOUND,
+                        "해당 DecisionLine에 연결된 시나리오를 찾을 수 없습니다."));
+
+        // 지표 조회
+        var sceneTypes = sceneTypeRepository.findByScenarioIdOrderByTypeAsc(scenario.getId());
+
+        // DTO 변환 및 반환
+        return ScenarioDetailResponse.from(scenario, sceneTypes);
+    }
+
     // 시나리오 타임라인 조회
     @Transactional(readOnly = true)
     public TimelineResponse getScenarioTimeline(Long scenarioId, Long userId) {


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**:
- 트리구조에서 시나리오Id를 조회할 수 있는 API를 추가했습니다.

- **왜(Why)**:
- 기존 API로는 트리구조에서는 시나리오Id를 알 수 없기때문입니다.

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- Decision라인Id를 통해 시나리오 Id를 찾을 수 있도록 구현했습니다.

## 영향 범위
- [x] **API 변경**
- [ ] **DB 마이그레이션**
- [x] **Breaking Change**
- [ ] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #105
<!-- auto-linked-issue:105 -->