### PR TITLE
[FIX]: LazyInitializationException 해결 - FETCH JOIN 적용

### DIFF
--- a/back/src/main/java/com/back/domain/scenario/service/ScenarioService.java
+++ b/back/src/main/java/com/back/domain/scenario/service/ScenarioService.java
@@ -230,8 +230,8 @@ public class ScenarioService {
             throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, "lastDecision.parentDecisionNodeId is required");
         }
 
-        // 부모 노드 id로 조회(없으면 404)
-        DecisionNode parent = decisionNodeRepository.findById(lastDecision.parentDecisionNodeId())
+        // 부모 노드 id로 조회(없으면 404) - DecisionLine과 User를 EAGER 로딩
+        DecisionNode parent = decisionNodeRepository.findWithLineAndUserById(lastDecision.parentDecisionNodeId())
                 .orElseThrow(() -> new ApiException(
                         ErrorCode.NODE_NOT_FOUND,
                         "parent decision node not found: " + lastDecision.parentDecisionNodeId()


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**: ScenarioService의 검증로직의 코드를 부분수정했습니다.
- **왜(Why)**: 기존 코드에서 발생하는 LazyInitializaionException을 해결하기위함입니다.

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- ensureSameLine에서 findWithLineAndUserById 사용
- DecisionLine과 User를 기존 Repository코드를 이용하여 EAGER 로딩하여 Lazy Loading 문제 해결
- 모든 검증 로직은 그대로 유지

## 영향 범위
- [ ] **API 변경**
- [ ] **DB 마이그레이션**
- [x] **Breaking Change**
- [ ] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [ ] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #119
<!-- auto-linked-issue:119 -->