### PR TITLE
[REFACTOR]: users info service 코드 리팩토링

### DIFF
--- a/back/src/main/java/com/back/domain/scenario/repository/ScenarioRepository.java
+++ b/back/src/main/java/com/back/domain/scenario/repository/ScenarioRepository.java
@@ -82,4 +82,17 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long> {
 
     @Query("select s.id from Scenario s where s.baseLine.id = :baseLineId")
     List<Long> findIdsByBaseLine_Id(@Param("baseLineId") Long baseLineId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+    UPDATE Scenario s
+       SET s.representative = 
+           CASE WHEN s.id = :scenarioId THEN true ELSE false END
+     WHERE s.user.id = :userId
+       AND (s.representative = true OR s.id = :scenarioId)
+    """)
+    void updateRepresentativeStatus(
+            @Param("userId") Long userId,
+            @Param("scenarioId") Long scenarioId
+    );
 }

--- a/back/src/main/java/com/back/domain/user/controller/UserInfoController.java
+++ b/back/src/main/java/com/back/domain/user/controller/UserInfoController.java
@@ -38,14 +38,14 @@ public class UserInfoController {
     @PostMapping("/users-info")
     public ResponseEntity<UserInfoResponse> createMyInfo(@AuthenticationPrincipal CustomUserDetails principal,
                                                          @Valid @RequestBody UserInfoRequest req) {
-        return ResponseEntity.ok(userInfoService.createMyInfo(principal.getId(), req));
+        return ResponseEntity.ok(userInfoService.saveOrUpdateMyInfo(principal.getId(), req));
     }
 
     // 사용자 정보 수정
     @PutMapping("/users-info")
     public ResponseEntity<UserInfoResponse> updateMyInfo(@AuthenticationPrincipal CustomUserDetails principal,
                                                          @Valid @RequestBody UserInfoRequest req) {
-        return ResponseEntity.ok(userInfoService.updateMyInfo(principal.getId(), req));
+        return ResponseEntity.ok(userInfoService.saveOrUpdateMyInfo(principal.getId(), req));
     }
 
     // 내가 만든 시나리오 목록 조회 (평행우주 목록)

--- a/back/src/main/java/com/back/domain/user/service/GuestService.java
+++ b/back/src/main/java/com/back/domain/user/service/GuestService.java
@@ -27,7 +27,7 @@ public class GuestService {
         User guest = User.builder()
                 .email(guestEmail)
                 .username(guestLoginId)
-                .password(null) // 게스트 비밀번호 없음(추후 전환 시 설정)
+                .password(null)
                 .nickname("게스트_" + UUID.randomUUID().toString().substring(0, 4))
                 .birthdayAt(LocalDateTime.now())
                 .role(Role.GUEST)


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**:
  - ScenarioRepository.updateRepresentativeStatus 추가
  - UserInfoService의 createMyInfo/updateMyInfo -> saveOrUpdateMyInfo로 통합
  - getMyScenarios에서 빈 ID 리스트 시 SceneType 조회 스킵 (불필요 쿼리 제거)
  - 입력 정제: username, beliefs에 trim() 적용

- **왜(Why)**:
  - 한 번의 업데이트로 대표 단일성 보장 및 트랜잭션 정합성 향상 
  - 동일 로직 중복 제거로 코드 단순화/유지보수성 개선
  - 빈 결과 조회 방지로 DB 부하 경감


## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- 쿼리 한 방으로 대표 시나리오 true/false 동시 처리
- saveOrUpdateMyInfo로 서비스 단일화
- scenarioIds.isEmpty() 시 SceneType 조회 생략, toList()로 간결화

## 영향 범위
- [ ] **API 변경**
- [ ] **DB 마이그레이션**
- [ ] **Breaking Change**
- [ ] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #133
<!-- auto-linked-issue:133 -->