### PR TITLE
[REFACTOR]: 배포환경 S3연결 및 이미지생성기능활성화

### DIFF
--- a/back/src/main/java/com/back/domain/scenario/entity/Scenario.java
+++ b/back/src/main/java/com/back/domain/scenario/entity/Scenario.java
@@ -78,7 +78,7 @@ public class Scenario extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String timelineTitles;  // {"2020": "대학원 진학", "2022": "연구실 변경", "2025": "해외 학회"} 형태
 
-    // 시나리오 대표 이미지 URL
+    // 시나리오 이미지 파일명
     private String img;
 
     // 대표 시나리오 여부

--- a/back/src/main/java/com/back/global/ai/config/ImageAiConfig.java
+++ b/back/src/main/java/com/back/global/ai/config/ImageAiConfig.java
@@ -40,6 +40,9 @@ public class ImageAiConfig {
     // AWS S3 리전 (storageType이 s3인 경우)
     private String s3Region;
 
+    // CloudFront 도메인 (storageType이 s3인 경우)
+    private String cloudFrontDomain;
+
     // 로컬 파일 저장 경로 (storageType="local"인 경우 사용)
     // 기본값: "./uploads/images"
     private String localStoragePath = "./uploads/images";

--- a/back/src/main/resources/application-prod.yml
+++ b/back/src/main/resources/application-prod.yml
@@ -77,7 +77,8 @@ custom:
 # AI Services Configuration (Production)
 ai:
   image:
-    enabled: false                                     # 프로덕션 환경에서는 활성화
+    enabled: true                                      # 프로덕션 환경에서는 활성화
     storage-type: s3                                  # S3 스토리지 사용
     s3-bucket-name: ${AWS_S3_BUCKET_NAME}
     s3-region: ${AWS_REGION}
+    cloud-front-domain: ${AWS_CLOUD_FRONT_DOMAIN}    # 향후 확장성 고려, 현재는 미사용


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**: 배포환경에서 S3를 연결하고 이미지생성기능을 활성화했습니다.
- **왜(Why)**: 배포환경에서 이미지생성 후 저장 및 호출을 원활히하기위함입니다.

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- 백엔드에는 파일명만 저장하고, 프론트에서 CDN도메인을 가지고있다가 프론트에서 파일명을 백엔드로부터 받아와 URL을 조합하여 CloudFront에 요청하는 방식을 채택한 결과, 백엔드에는 파일명만 저장하도록 변경했습니다.

## 영향 범위
- [ ] **API 변경**
- [ ] **DB 마이그레이션**
- [ ] **Breaking Change**
- [ ] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [x] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #143
<!-- auto-linked-issue:143 -->