### PR TITLE
[FIX]: 엔티티 상 searchVector 필드 제거, 데이터베이스 컬럼 상으로는 존재

### DIFF
--- a/back/src/main/java/com/back/domain/post/entity/Post.java
+++ b/back/src/main/java/com/back/domain/post/entity/Post.java
@@ -76,19 +76,6 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "scenario_id")
     private Scenario scenario;
 
-    /**
-     * 마이그레이션 alter문으로 postgreSQL tsvector 타입 컬럼 지정
-     * - 트리거에 의해 자동으로 업데이트됨
-     * - 직접 값을 설정할 필요 없음
-     * - GIN 인덱스로 빠른 검색 지원
-     */
-    @Column(
-            name = "search_vector",
-            insertable = false,
-            updatable = false
-    )
-    private String searchVector;
-
     public void updatePost(String title, String content, PostCategory category) {
         this.title = title;
         this.content = content;


### PR DESCRIPTION
> **제목(필수)**: `[TYPE]: 제목`  예) `[FEAT]: 회원가입 기능 추가`
<details>
<summary>제목 규칙 자세히 보기</summary>

- 형식: `[TYPE]: 제목`
- 제한: **50자 이내**, 첫 글자 대문자, **명령문**
- TYPE: `FEAT` `FIX` `REFACTOR` `COMMENT` `STYLE` `TEST` `CHORE` `INIT`
</details>

---

## 무엇을 / 왜
- **무엇(What)**:  게시글 searchVector 필드를 제거하였습니다.
- **왜(Why)**: ddl-auto 설정 충돌로 인함

## 어떻게(요약) — 3줄 이내
<!-- 핵심 변경점/설계 흐름/의존성 요약 -->
- 게시글 엔티티 상 searchVector 필드를 제거, db에서 마이그레이션 하는 방향으로 수정하였습니다.

## 영향 범위
- [ ] **API 변경**
- [ ] **DB 마이그레이션**
- [x] **Breaking Change**
- [ ] **보안/권한 영향**
- [ ] 문서/가이드 업데이트 필요

## 체크리스트
- [x] 타입 라벨 부착 (FEAT/FIX/REFACTOR/COMMENT/STYLE/TEST/CHORE/INIT)
- [x] 로컬/CI 테스트 통과
- [ ] 영향도 점검 완료
- [x] 주석/문서 반영(필요 시)

## ToDo (선택)
- [ ] 할 일 1
- [ ] 할 일 2


## 스크린샷/증빙(선택)
<!-- 이미지/로그 첨부 -->

## 이슈 연결 (자동)
<!-- 아래 라인은 액션이 자동으로 채웁니다. 직접 쓰지 마세요.
예: Cl0ses #123  (자동 주입)
-->

Closes #149
<!-- auto-linked-issue:149 -->